### PR TITLE
[WIP] Feature: Create detailed contribution documentation and code examples

### DIFF
--- a/slitherton/__main__.py
+++ b/slitherton/__main__.py
@@ -18,8 +18,10 @@ async def ping(ctx):
     await ctx.send("PONG")
 
 
-# Register Cogs with bot (disabled for now as there are no cogs)
-# for cog in (ROOT_DIR / "cogs").glob("*.py"):
-#     bot.add_cog(f"cogs.{cog}")
+# Register Cogs with bot
+for cog in (ROOT_DIR / "cogs").glob("*.py"):
+    print(f"Found cog: 'cog.{cog.name[:-3]}'")
+    bot.load_extension(f"slitherton.cogs.{cog.name[:-3]}")
+
 
 bot.run(config("DISCORD_BOT_KEY"))

--- a/slitherton/cogs/example.py
+++ b/slitherton/cogs/example.py
@@ -1,0 +1,41 @@
+from discord.ext import commands
+
+
+class Example(commands.Cog):
+    def __init__(self, client):
+        """
+        The init function will always take a client, which represents the particular bot that is using the cog.
+        """
+        self.client = client
+
+    @commands.Cog.listener()
+    async def on_ready(self):
+        """
+        Any listeners you add will be effectively merged with the global listeners,
+        which means you can have multiple cogs listening for the same events and
+        taking actions based on those events.
+        """
+        print("Example extension has been loaded")
+
+    @commands.command()
+    async def yoohoo(self, ctx):
+        """
+        This is a useless example command to demonstrate how commands can be added to
+        the cog and then made available to the bot when the cog is loaded.
+
+        I should note here that the command/function's docstring (this text right here)
+        will be used by the bot as its "help" and example text by default.
+
+        More information can be found in the discord.py docs or our contributing docs.
+        """
+        await ctx.send("Yoohoo! This command runs in the Example cog")
+
+
+def setup(client):
+    """
+    This setup function must exist in every cog file and will ultimately have a
+    nearly identical signiture and logic to what you're seeing here.
+
+    It's ultimately what loads the Cog into the bot.
+    """
+    client.add_cog(Example(client))


### PR DESCRIPTION
In order to provide the best onboarding and contribution experience possible for all Py-Lambdans, our documentation and examples need to be inviting to those who have widely varying experience with both Python projects and open source contributions. 

To that end, this PR will serve as the working branch for ensuring that we're ready on day 1 for contributions from everyone.

Closes: #2 